### PR TITLE
utils: fix script root dir for creation script

### DIFF
--- a/create_cleanconll_from_conll03.sh
+++ b/create_cleanconll_from_conll03.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+SCRIPT_ROOT=$(pwd)
 URL="https://data.deepai.org/conll2003.zip"
 CONLL03_DIR="$SCRIPT_ROOT/data/conll03/"
 PATCH_DIR="$SCRIPT_ROOT/data/patch_files"


### PR DESCRIPTION
Hi,

this PR sets the `SCRIPT_ROOT` variable correctly to current working dir, so that the script is working.

Initially, the variable was not set, so e.g. the data folder is expected at `/data` instead of `/.data` which causes an error when running the script.